### PR TITLE
Configure timeouts when backing up from etcd

### DIFF
--- a/pkg/backup/backup_manager.go
+++ b/pkg/backup/backup_manager.go
@@ -120,9 +120,11 @@ func getClientWithMaxRev(ctx context.Context, endpoints []string, tc *tls.Config
 	for _, endpoint := range endpoints {
 		// TODO: update clientv3 to 3.2.x and then use ctx as in clientv3.Config.
 		cfg := clientv3.Config{
-			Endpoints:   []string{endpoint},
-			DialTimeout: constants.DefaultDialTimeout,
-			TLS:         tc,
+			Endpoints:            []string{endpoint},
+			DialTimeout:          constants.DefaultDialTimeout,
+			DialKeepAliveTime:    constants.DefaultDialKeepAliveTime,
+			DialKeepAliveTimeout: constants.DefaultDialKeepAliveTimeout,
+			TLS:                  tc,
 		}
 		etcdcli, err := clientv3.New(cfg)
 		if err != nil {

--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -17,7 +17,9 @@ package constants
 import "time"
 
 const (
-	DefaultDialTimeout    = 5 * time.Second
+	DefaultDialTimeout    = 30 * time.Second
+	DefaultDialKeepAliveTime = 10 * time.Second
+	DefaultDialKeepAliveTimeout = 120 * time.Second
 	DefaultRequestTimeout = 5 * time.Second
 	// DefaultBackupTimeout is the default maximal allowed time of the entire backup process.
 	DefaultBackupTimeout    = 1 * time.Minute

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	Version = "0.9.5"
+	Version = "0.9.4-strato-0.2"
 	GitSHA  = "Not provided (use ./build instead of go build)"
 )


### PR DESCRIPTION
Hopefully this will improve the reliability (of which there is not much
right now) of the etcd backup operator.
