### PR TITLE
Add support for SecretTypeTLS secrets

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -370,7 +370,6 @@ func (c *Cluster) isPodPVEnabled() bool {
 }
 
 func (c *Cluster) createPod(members etcdutil.MemberSet, m *etcdutil.Member, state string) error {
-	c.logger.Info("Creating pod")
 	pod, err := k8sutil.NewEtcdPod(c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, uuid.New(), c.cluster.Spec, c.cluster.AsOwner())
 	if c.isPodPVEnabled() {
 		pvc := k8sutil.NewEtcdPodPVC(m, *c.cluster.Spec.Pod.PersistentVolumeClaimSpec, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -370,7 +370,7 @@ func (c *Cluster) isPodPVEnabled() bool {
 }
 
 func (c *Cluster) createPod(members etcdutil.MemberSet, m *etcdutil.Member, state string) error {
-	pod := k8sutil.NewEtcdPod(m, members.PeerURLPairs(), c.cluster.Name, state, uuid.New(), c.cluster.Spec, c.cluster.AsOwner())
+	pod := k8sutil.NewEtcdPod(c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, uuid.New(), c.cluster.Spec, c.cluster.AsOwner())
 	if c.isPodPVEnabled() {
 		pvc := k8sutil.NewEtcdPodPVC(m, *c.cluster.Spec.Pod.PersistentVolumeClaimSpec, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
 		_, err := c.config.KubeCli.CoreV1().PersistentVolumeClaims(c.cluster.Namespace).Create(pvc)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -370,7 +370,8 @@ func (c *Cluster) isPodPVEnabled() bool {
 }
 
 func (c *Cluster) createPod(members etcdutil.MemberSet, m *etcdutil.Member, state string) error {
-	pod := k8sutil.NewEtcdPod(c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, uuid.New(), c.cluster.Spec, c.cluster.AsOwner())
+	c.logger.Info("Creating pod")
+	pod, err := k8sutil.NewEtcdPod(c.config.KubeCli, m, members.PeerURLPairs(), c.cluster.Name, c.cluster.Namespace, state, uuid.New(), c.cluster.Spec, c.cluster.AsOwner())
 	if c.isPodPVEnabled() {
 		pvc := k8sutil.NewEtcdPodPVC(m, *c.cluster.Spec.Pod.PersistentVolumeClaimSpec, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
 		_, err := c.config.KubeCli.CoreV1().PersistentVolumeClaims(c.cluster.Namespace).Create(pvc)
@@ -381,7 +382,7 @@ func (c *Cluster) createPod(members etcdutil.MemberSet, m *etcdutil.Member, stat
 	} else {
 		k8sutil.AddEtcdVolumeToPod(pod, nil)
 	}
-	_, err := c.config.KubeCli.CoreV1().Pods(c.cluster.Namespace).Create(pod)
+	_, err = c.config.KubeCli.CoreV1().Pods(c.cluster.Namespace).Create(pod)
 	return err
 }
 

--- a/pkg/controller/restore-operator/sync.go
+++ b/pkg/controller/restore-operator/sync.go
@@ -223,7 +223,7 @@ func (r *Restore) createSeedMember(ec *api.EtcdCluster, svcAddr, namespace strin
 	ms := etcdutil.NewMemberSet(m)
 	backupURL := backupapi.BackupURLForRestore("http", svcAddr, clusterName, namespace)
 	ec.SetDefaults()
-	pod := k8sutil.NewSeedMemberPod(clusterName, ms, m, ec.Spec, owner, backupURL)
+	pod := k8sutil.NewSeedMemberPod(r.kubecli, clusterName, namespace, ms, m, ec.Spec, owner, backupURL)
 	_, err := r.kubecli.Core().Pods(ec.Namespace).Create(pod)
 	return err
 }

--- a/pkg/controller/restore-operator/sync.go
+++ b/pkg/controller/restore-operator/sync.go
@@ -223,8 +223,8 @@ func (r *Restore) createSeedMember(ec *api.EtcdCluster, svcAddr, namespace strin
 	ms := etcdutil.NewMemberSet(m)
 	backupURL := backupapi.BackupURLForRestore("http", svcAddr, clusterName, namespace)
 	ec.SetDefaults()
-	pod := k8sutil.NewSeedMemberPod(r.kubecli, clusterName, namespace, ms, m, ec.Spec, owner, backupURL)
-	_, err := r.kubecli.Core().Pods(ec.Namespace).Create(pod)
+	pod, err := k8sutil.NewSeedMemberPod(r.kubecli, clusterName, namespace, ms, m, ec.Spec, owner, backupURL)
+	_, err = r.kubecli.Core().Pods(ec.Namespace).Create(pod)
 	return err
 }
 

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -270,9 +270,9 @@ func addOwnerRefToObject(o metav1.Object, r metav1.OwnerReference) {
 
 // NewSeedMemberPod returns a Pod manifest for a seed member.
 // It's special that it has new token, and might need recovery init containers
-func NewSeedMemberPod(kubecli kubernetes.Interface, clusterName, clusterNamespace string, ms etcdutil.MemberSet, m *etcdutil.Member, cs api.ClusterSpec, owner metav1.OwnerReference, backupURL *url.URL) *v1.Pod {
+func NewSeedMemberPod(kubecli kubernetes.Interface, clusterName, clusterNamespace string, ms etcdutil.MemberSet, m *etcdutil.Member, cs api.ClusterSpec, owner metav1.OwnerReference, backupURL *url.URL) (*v1.Pod, error) {
 	token := uuid.New()
-	pod := newEtcdPod(kubecli, m, ms.PeerURLPairs(), clusterName, clusterNamespace, "new", token, cs)
+	pod, err := newEtcdPod(kubecli, m, ms.PeerURLPairs(), clusterName, clusterNamespace, "new", token, cs)
 	// TODO: PVC datadir support for restore process
 	AddEtcdVolumeToPod(pod, nil)
 	if backupURL != nil {
@@ -280,7 +280,7 @@ func NewSeedMemberPod(kubecli kubernetes.Interface, clusterName, clusterNamespac
 	}
 	applyPodPolicy(clusterName, pod, cs.Pod)
 	addOwnerRefToObject(pod.GetObjectMeta(), owner)
-	return pod
+	return pod, err
 }
 
 // NewEtcdPodPVC create PVC object from etcd pod's PVC spec
@@ -297,14 +297,17 @@ func NewEtcdPodPVC(m *etcdutil.Member, pvcSpec v1.PersistentVolumeClaimSpec, clu
 	return pvc
 }
 
-func newEtcdPod(kubecli kubernetes.Interface, m *etcdutil.Member, initialCluster []string, clusterName, clusterNamespace, state, token string, cs api.ClusterSpec) *v1.Pod {
+func newEtcdPod(kubecli kubernetes.Interface, m *etcdutil.Member, initialCluster []string, clusterName, clusterNamespace, state, token string, cs api.ClusterSpec) (*v1.Pod, error) {
 	commands := fmt.Sprintf("/usr/local/bin/etcd --data-dir=%s --name=%s --initial-advertise-peer-urls=%s "+
 		"--listen-peer-urls=%s --listen-client-urls=%s --advertise-client-urls=%s "+
 		"--initial-cluster=%s --initial-cluster-state=%s",
 		dataDir, m.Name, m.PeerURL(), m.ListenPeerURL(), m.ListenClientURL(), m.ClientURL(), strings.Join(initialCluster, ","), state)
 	if m.SecurePeer {
 		secret, err := kubecli.CoreV1().Secrets(clusterNamespace).Get(cs.TLS.Static.Member.PeerSecret, metav1.GetOptions{})
-		if err == nil && secret.Type == v1.SecretTypeTLS {
+		if err != nil {
+			return nil, err
+		}
+		if secret.Type == v1.SecretTypeTLS {
 			commands += fmt.Sprintf(" --peer-client-cert-auth=true --peer-trusted-ca-file=%[1]s/ca.crt --peer-cert-file=%[1]s/tls.crt --peer-key-file=%[1]s/tls.key", peerTLSDir)
 		} else {
 			commands += fmt.Sprintf(" --peer-client-cert-auth=true --peer-trusted-ca-file=%[1]s/peer-ca.crt --peer-cert-file=%[1]s/peer.crt --peer-key-file=%[1]s/peer.key", peerTLSDir)
@@ -312,8 +315,11 @@ func newEtcdPod(kubecli kubernetes.Interface, m *etcdutil.Member, initialCluster
 	}
 	if m.SecureClient {
 		secret, err := kubecli.CoreV1().Secrets(clusterNamespace).Get(cs.TLS.Static.Member.ServerSecret, metav1.GetOptions{})
-		if err == nil && secret.Type == v1.SecretTypeTLS {
-			commands += fmt.Sprintf(" --peer-client-cert-auth=true --peer-trusted-ca-file=%[1]s/ca.crt --peer-cert-file=%[1]s/tls.crt --peer-key-file=%[1]s/tls.key", serverTLSDir)
+		if err != nil {
+			return nil, err
+		}
+		if secret.Type == v1.SecretTypeTLS {
+			commands += fmt.Sprintf(" --client-cert-auth=true --trusted-ca-file=%[1]s/ca.crt --cert-file=%[1]s/tls.crt --key-file=%[1]s/tls.key", serverTLSDir)
 		} else {
 			commands += fmt.Sprintf(" --client-cert-auth=true --trusted-ca-file=%[1]s/server-ca.crt --cert-file=%[1]s/server.crt --key-file=%[1]s/server.key", serverTLSDir)
 		}
@@ -413,7 +419,7 @@ func newEtcdPod(kubecli kubernetes.Interface, m *etcdutil.Member, initialCluster
 		},
 	}
 	SetEtcdVersion(pod, cs.Version)
-	return pod
+	return pod, nil
 }
 
 func podSecurityContext(podPolicy *api.PodPolicy) *v1.PodSecurityContext {
@@ -423,11 +429,11 @@ func podSecurityContext(podPolicy *api.PodPolicy) *v1.PodSecurityContext {
 	return podPolicy.SecurityContext
 }
 
-func NewEtcdPod(kubecli kubernetes.Interface, m *etcdutil.Member, initialCluster []string, clusterName, clusterNamespace, state, token string, cs api.ClusterSpec, owner metav1.OwnerReference) *v1.Pod {
-	pod := newEtcdPod(kubecli, m, initialCluster, clusterName, clusterNamespace, state, token, cs)
+func NewEtcdPod(kubecli kubernetes.Interface, m *etcdutil.Member, initialCluster []string, clusterName, clusterNamespace, state, token string, cs api.ClusterSpec, owner metav1.OwnerReference) (*v1.Pod, error) {
+	pod, err := newEtcdPod(kubecli, m, initialCluster, clusterName, clusterNamespace, state, token, cs)
 	applyPodPolicy(clusterName, pod, cs.Pod)
 	addOwnerRefToObject(pod.GetObjectMeta(), owner)
-	return pod
+	return pod, err
 }
 
 func MustNewKubeClient() kubernetes.Interface {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -340,7 +340,7 @@ func newEtcdPod(kubecli kubernetes.Interface, m *etcdutil.Member, initialCluster
 		if err != nil {
 			return nil, err
 		}
-			isTLSSecret = secret.Type == v1.SecretTypeTLS
+		isTLSSecret = secret.Type == v1.SecretTypeTLS
 	}
 	livenessProbe := newEtcdProbe(cs.TLS.IsSecureClient(), isTLSSecret)
 	readinessProbe := newEtcdProbe(cs.TLS.IsSecureClient(), isTLSSecret)

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -340,9 +340,7 @@ func newEtcdPod(kubecli kubernetes.Interface, m *etcdutil.Member, initialCluster
 		if err != nil {
 			return nil, err
 		}
-		if secret.Type == v1.SecretTypeTLS {
-			isTLSSecret = true
-		}
+			isTLSSecret = secret.Type == v1.SecretTypeTLS
 	}
 	livenessProbe := newEtcdProbe(cs.TLS.IsSecureClient(), isTLSSecret)
 	readinessProbe := newEtcdProbe(cs.TLS.IsSecureClient(), isTLSSecret)

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -68,11 +68,14 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 	return c
 }
 
-func newEtcdProbe(isSecure bool) *v1.Probe {
+func newEtcdProbe(isSecure, isTLSSecret bool) *v1.Probe {
 	// etcd pod is healthy only if it can participate in consensus
 	cmd := "ETCDCTL_API=3 etcdctl endpoint health"
 	if isSecure {
 		tlsFlags := fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, etcdutil.CliCertFile, etcdutil.CliKeyFile, etcdutil.CliCAFile)
+		if isTLSSecret {
+			tlsFlags = fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, "tls.crt", "tls.key", "ca.crt")
+		}
 		cmd = fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=https://localhost:%d %s endpoint health", EtcdClientPort, tlsFlags)
 	}
 	return &v1.Probe{

--- a/pkg/util/k8sutil/tls.go
+++ b/pkg/util/k8sutil/tls.go
@@ -16,6 +16,7 @@ package k8sutil
 
 import (
 	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
+	v1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/util/k8sutil/tls.go
+++ b/pkg/util/k8sutil/tls.go
@@ -15,10 +15,10 @@
 package k8sutil
 
 import (
-	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
 	v1 "k8s.io/api/core/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/pkg/util/k8sutil/tls.go
+++ b/pkg/util/k8sutil/tls.go
@@ -33,6 +33,15 @@ func GetTLSDataFromSecret(kubecli kubernetes.Interface, ns, se string) (*TLSData
 	if err != nil {
 		return nil, err
 	}
+
+	if secret.Type == v1.SecretTypeTLS {
+		return &TLSData{
+			CertData: secret.Data["tls.crt"],
+			KeyData:  secret.Data["tls.key"],
+			CAData:   secret.Data["ca.crt"],
+		}, nil
+	}
+
 	return &TLSData{
 		CertData: secret.Data[etcdutil.CliCertFile],
 		KeyData:  secret.Data[etcdutil.CliKeyFile],

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	Version = "0.9.4-strato-0.3"
+	Version = "0.9.4-strato-0.4"
 	GitSHA  = "Not provided (use ./build instead of go build)"
 )


### PR DESCRIPTION
Kubernetes knows specific TLS secrets (SecretTypeTLS). This kind of
secrets has specifically named fields (tls.crt, tls.key, ca.crt)
different from those supported by the etcd-operator. Such secretes
are e.g. generated by the cert-manager. This change adds support for
such secrets.


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
